### PR TITLE
Add search for all languages to the UI

### DIFF
--- a/suggestedimages/locales/cldr_names.py
+++ b/suggestedimages/locales/cldr_names.py
@@ -1,10 +1,17 @@
 import langcodes
 
 class LanguageNames:
-    def __init__(self, lang, custom_names):
+    def __init__(self, lang = 'en', custom_names = {}):
         self.lang = lang
         self.custom_names = custom_names
 
     def __getitem__(self, key):
         return self.custom_names.get(key) \
             or langcodes.Language.get(key).display_name(self.lang)
+
+
+    def keys(self):
+        return sorted(
+            set(langcodes.LANGUAGE_ALPHA3.keys())
+            | set(self.custom_names.keys())
+        )

--- a/suggestedimages/locales/locale.py
+++ b/suggestedimages/locales/locale.py
@@ -1,12 +1,11 @@
 import langcodes
 import importlib
 
+from .cldr_names import LanguageNames
 from .list_of_wiktionaries import language_of_wiktionary
 
 
-class DefaultLanguageNames:
-    def __getitem__(self, key):
-        return langcodes.Language.get(key).display_name()
+
 
 
 class Locale:
@@ -21,6 +20,7 @@ class Locale:
         try:
             self.module = importlib.import_module(f'suggestedimages.locales.{wikt}')
         except ImportError:
+            print(f"Couldn't load module: {wikt}")
             self.module = None
 
     def __repr__(self):
@@ -40,5 +40,5 @@ class Locale:
     @property
     def language_names(self):
         if not self.module or not self.module.language_names:
-            return DefaultLanguageNames()
+            return LanguageNames()
         return self.module.language_names

--- a/suggestedimages/routes.py
+++ b/suggestedimages/routes.py
@@ -2,31 +2,47 @@ from flask import (
     Blueprint, flash, redirect, render_template, request, url_for
 )
 import urllib
+from collections import namedtuple
+
 
 from . import search
 from .util import StrInLanguage
 from .locales import Locale
+
+LangOption = namedtuple("LangOption", "value label")
 
 bp = Blueprint('main', __name__)
 
 @bp.route('/', methods=('GET',))
 def index():
     title = request.args.get('title')
-    if not title:
-        return render_template('index.html', results=[], locale=Locale())
-
     wikt = request.args.get('wikt')
     locale = Locale(wikt) if wikt else Locale()
     lang = request.args.get('lang') or locale.language
-    lang_str = StrInLanguage(title, lang=lang)
+
+    language_options = [
+        LangOption(
+            value = lang,
+            label = locale.language_names[lang] + f' [{lang}]'
+        ) for lang in
+            locale.language_names.keys()
+    ]
+
+    if not title:
+        return render_template('index.html',
+                               results=[],
+                               locale=locale,
+                               language_options=language_options)
+
+    title_with_lang = StrInLanguage(title, lang=lang)
     encoded_title = urllib.parse.quote(title.replace(' ', '_'), safe='/', encoding=None, errors=None)
     edit_url = f"https://{wikt}.wiktionary.org/w/index.php?title={encoded_title}&action=edit" if wikt else None
     view_url = f"https://{wikt}.wiktionary.org/wiki/{encoded_title}" if wikt else None
 
-
     return render_template('index.html',
-                           results=search.get_images_for_word_ranked(lang_str, locale),
+                           results=search.get_images_for_word_ranked(title_with_lang, locale),
                            edit_url=edit_url,
                            view_url=view_url,
                            locale=locale,
+                           language_options=language_options,
                            get_color_class=search.GetColorClass())

--- a/suggestedimages/search/lexemes.py
+++ b/suggestedimages/search/lexemes.py
@@ -55,7 +55,7 @@ def yield_images(sense_generator: Iterator, searched: StrInLanguage, locale: Loc
 
 def get_sense_description(entry, searched: StrInLanguage, locale: Locale) -> SenseEntry:
     label = entry.on_lexeme.text['lemmas'].get(searched.language)
-    meaning = StrInLanguages(entry.glosses).get(locale.language)
+    meaning = StrInLanguages(entry.glosses).get(locale.language) or StrInLanguages(entry.glosses).get('en')
     if not meaning and searched.language != 'en':
         meaning = StrInLanguages(entry.glosses).get('en')
 
@@ -63,7 +63,7 @@ def get_sense_description(entry, searched: StrInLanguage, locale: Locale) -> Sen
         entry.id,
         label,
         entry.on_lexeme.id,
-        text = f'{label} ’{meaning}’'
+        text = f'{label}' + (f' ’{meaning}’' if meaning else '')
     )
 
 

--- a/suggestedimages/static/index.js
+++ b/suggestedimages/static/index.js
@@ -1,34 +1,61 @@
-function updateLanguage(langElem) {
-    const code = langElem.value;
-    const option = document.querySelector('#languages').querySelector('option[value="' + code + '"]');
-    if ( option ) {
-        langElem.setCustomValidity("");
-        document.querySelector('#language-name').textContent = option.textContent.replace(/ \[.*\]/, '');
-    } else if ( code == "" ) {
-        langElem.setCustomValidity("");
-        document.querySelector('#language-name').textContent = "(same)";
+function setLanguageNameDisplay(text) {
+    document.querySelector('#language-name').textContent = text;
+}
 
+function extractLanguageNameFromOptionLabel(optionValue) {
+    // For example, 'Spanish [es]' –> 'Spanish'
+    return optionValue.replace(/ \[.*\]/, '');
+}
+
+function handleChangedLanguage(languageInput) {
+    const code = languageInput.value;
+    const option = document.querySelector('#languages').querySelector('option[value="' + code + '"]');
+
+    if ( option ) {
+        setLanguageNameDisplay(extractLanguageNameFromOptionLabel(otion.textContent));
+        languageInput.setCustomValidity("");
+    } else if ( code == "" ) {
+        setLanguageNameDisplay("(same)");
+        languageInput.setCustomValidity("");
     } else {
-        langElem.setCustomValidity("Invalid language code");
-        document.querySelector('#language-name').textContent = "";
+        setLanguageNameDisplay("");
+        languageInput.setCustomValidity("Invalid language code");
     }
 }
 
+function focusTitleInputAndSelectText() {
+    // The HTML autofocus attribute just focuses, but doesn't select the
+    // text, so we have to do it ourselves.
+    document.getElementById('title').select();
+}
+
+function titleInputIsEmpty() {
+    return (document.getElementById('title').value.trim() === "");
+}
+
+
+function showLoadingIndicator() {
+    document.querySelector('.gallery').style.display = 'block';
+}
+
+function hideGallery(isLoading) {
+    document.querySelector('.loading-message').style.display = 'none';
+}
+
+
 document.addEventListener("DOMContentLoaded", (event) => {
-    const textbox = document.getElementById('title');
-    if ( textbox.value.trim() !== "" ) {
-        document.getElementById('title').select();
+    if ( ! titleInputIsEmpty() ) {
+        focusTitleInputAndSelectText();
     }
-    updateLanguage(document.querySelector('#lang'));
+    handleChangedLanguage(document.querySelector('#lang'));
 });
 
-document.querySelector('#wikt').addEventListener("change", (event) => {
+document.forms[0].wikt.addEventListener("change", (event) => {
     document.forms[0].submit();
 });
 
-
 document.forms[0].addEventListener("submit", (event) => {
-    // Disable empty inputs, so it is not submitted as a parametre and clutter the url.
+    // Disable empty inputs, so they are not submitted as parametres and clutter the url.
     if ( document.forms[0].lang.value === "" ) {
         document.forms[0].lang.setAttribute("disabled", true);
     }
@@ -37,11 +64,9 @@ document.forms[0].addEventListener("submit", (event) => {
         document.forms[0].title.setAttribute("disabled", true);
     }
 
-    document.querySelector('.gallery').style.display = 'none';
-    document.querySelector('.loading-message').style.display = 'block';
+    showLoadingIndicator();
+    // Hide the gallery temporarily to make the changing of results more visible.
+    hideGallery();
 });
 
-
-
-document.querySelector('#lang')
-        .addEventListener('input', (event) => updateLanguage(event.target));
+document.forms[0].lang.addEventListener('input', (event) => handleChangedLanguage(event.target));

--- a/suggestedimages/static/index.js
+++ b/suggestedimages/static/index.js
@@ -1,8 +1,25 @@
+function updateLanguage(langElem) {
+    const code = langElem.value;
+    const option = document.querySelector('#languages').querySelector('option[value="' + code + '"]');
+    if ( option ) {
+        langElem.setCustomValidity("");
+        document.querySelector('#language-name').textContent = option.textContent.replace(/ \[.*\]/, '');
+    } else if ( code == "" ) {
+        langElem.setCustomValidity("");
+        document.querySelector('#language-name').textContent = "(same)";
+
+    } else {
+        langElem.setCustomValidity("Invalid language code");
+        document.querySelector('#language-name').textContent = "";
+    }
+}
+
 document.addEventListener("DOMContentLoaded", (event) => {
     const textbox = document.getElementById('title');
-    if ( textbox.value !== "" ) {
+    if ( textbox.value.trim() !== "" ) {
         document.getElementById('title').select();
     }
+    updateLanguage(document.querySelector('#lang'));
 });
 
 document.querySelector('#wikt').addEventListener("change", (event) => {
@@ -23,3 +40,8 @@ document.forms[0].addEventListener("submit", (event) => {
     document.querySelector('.gallery').style.display = 'none';
     document.querySelector('.loading-message').style.display = 'block';
 });
+
+
+
+document.querySelector('#lang')
+        .addEventListener('input', (event) => updateLanguage(event.target));

--- a/suggestedimages/static/style.css
+++ b/suggestedimages/static/style.css
@@ -252,13 +252,15 @@ input:invalid {
     box-shadow: 0px 0px 5px red;
 }
 
-
-
 input:invalid + span::before {
   content: "✖";
   color: red;
 }
 
+input:valid + span::before {
+  content: "✔";
+  color: green;
+}
 
 
 

--- a/suggestedimages/static/style.css
+++ b/suggestedimages/static/style.css
@@ -248,8 +248,18 @@ input[type=submit] {
 
 
 input:invalid {
-    border: solid red 2px;
+    border: 1px solid rgba(255, 0, 0, 0.7);
+    box-shadow: 0px 0px 5px red;
 }
+
+
+
+input:invalid + span::before {
+  content: "✖";
+  color: red;
+}
+
+
 
 
 #lang {

--- a/suggestedimages/static/style.css
+++ b/suggestedimages/static/style.css
@@ -244,3 +244,28 @@ input[type=submit] {
     max-height: 1em;
     max-width: 1em;
 }
+
+
+
+input:invalid {
+    border: solid red 2px;
+}
+
+
+#lang {
+  width: 20em;
+  font-size: 13.3333px;
+  z-index: 1;
+  position: absolute;
+  background: transparent;
+}
+
+#language-name {
+  position: relative;
+  width: 20em;
+  text-align: right;
+  display: inline-block;
+  font-size: 13px;
+  z-index: 0;
+  color: slategray;
+}

--- a/suggestedimages/templates/index.html
+++ b/suggestedimages/templates/index.html
@@ -14,15 +14,17 @@
       <option value="sv" {{ "selected" if request.args.get('wikt') == 'sv' }}>svenska</option>
     </select>
     <label for="title">{{ locale['Language'] }}</label>
-    <select name="lang" id="lang">
-      <option value="" {{ "selected" if request.args.get('lang') == '' }}>{{ locale['(same)'] }}</option>
-      <option value="fi" {{ "selected" if request.args.get('lang') == 'fi' }}>{{ locale.language_names['fi'] }}</option>
-      <option value="en" {{ "selected" if request.args.get('lang') == 'en' }}>{{ locale.language_names['en'] }}</option>
-      <option value="es" {{ "selected" if request.args.get('lang') == 'es' }}>{{ locale.language_names['es'] }}</option>
-      <option value="sv" {{ "selected" if request.args.get('lang') == 'sv' }}>{{ locale.language_names['sv'] }}</option>
-    </select>
+    <div>
+      <input list="languages" name="lang" id="lang" value="{{ request.args.get('lang') or '' }}" /> <span id="language-name">
+      </span>
+      <datalist id="languages">
+        {% for option in language_options %}
+        <option value="{{ option.value }}">{{ option.label }}</option>
+        {% endfor %}
+      </datalist>
+    </div>
     <label for="title">{{ locale['Title'] }}</label>
-    <input name="title" id="title" value="{{ request.args.get('title') or "" }}" required autofocus>
+    <input name="title" id="title" value="{{ request.args.get('title') or '' }}" required autofocus>
     <input type="submit" value="{{ locale['Search'] }}">
   </form>
   <div class="link-bar">


### PR DESCRIPTION
- Add search widget for a localised list of languages.
- Add list of all languages with ISO codes and possible custom codes as the search space.
- Languages default to names from the CLDR database, but individual language can be overridden in the localisation.
- Validation in the widget for valid codes.

Implements #7

